### PR TITLE
Remove lower-case conversion of assemblyName var due execution problem

### DIFF
--- a/stracciatella.cna
+++ b/stracciatella.cna
@@ -271,7 +271,8 @@ sub executeAssembly {
             $assemblyName = substr($assemblyName, 0, $pos);
         }
 
-        $assemblyName = lc($assemblyName);
+        #Temporary comment-out the lower-case assemblyName due problems with BOF.NET
+        #$assemblyName = lc($assemblyName);
 
         if($job)
         {


### PR DESCRIPTION
Hi (again)! Im playing with that tool and notices strange problem with running via BOF.NET (this fork https://github.com/williamknows/BOF.NET)

When i loaded an BOF.NET and Stracciatella using "bofnet_init" and "bofnet_loadstracciatella" im trying to run simply "pwd" command. But im getting error message "[!] Cannot continue execution, specified .NET assembly not loaded". So i just copied command after "via" keyword and changed "s" in "Straciatella" to uppercase (as Stracciatella.exe filename) the execution works perfectly
![image](https://user-images.githubusercontent.com/2500114/170801948-72c2a267-bb32-4e75-bacd-249db20e0200.png)

I fixed it locally just commenting out the line mentioned below and it works perfectly!
https://github.com/mgeeky/Stracciatella/blob/a7d3d252ef0c24ea0bbb45b49dc231be8a1b8f80/stracciatella.cna#L274

You can merge it or analyze why i this problem appear

Amazing tool!
Purple regards ;)